### PR TITLE
Add support for linum, hl-line, yasnippet

### DIFF
--- a/color-theme-twilight.el
+++ b/color-theme-twilight.el
@@ -53,6 +53,11 @@
 	  (ido-only-match ((t (:foreground "#8F9D6A"))))
 	  (mumamo-background-chunk-submode ((t (:background "#222222")))) 
 
+	  (linum ((t (:foreground "#757575"))))
+	  (linum ((t (:background "#DCDCDC"))))
+	  (hl-line ((t (:background "#212121"))))  
+	  (yas/field-highlight-face ((t (:background "#27292A"))))
+
 	  (font-lock-string-face ((t (:foreground "#8F9D6A"))))
 	  (font-lock-type-face ((t (:foreground "#9B703F"))))
 	  (font-lock-variable-name-face ((t (:foreground "#7587A6"))))

--- a/color-theme-twilight.el
+++ b/color-theme-twilight.el
@@ -53,8 +53,7 @@
 	  (ido-only-match ((t (:foreground "#8F9D6A"))))
 	  (mumamo-background-chunk-submode ((t (:background "#222222")))) 
 
-	  (linum ((t (:foreground "#757575"))))
-	  (linum ((t (:background "#DCDCDC"))))
+	  (linum ((t (:background "#DCDCDC" :foreground "#757575"))))
 	  (hl-line ((t (:background "#212121"))))  
 	  (yas/field-highlight-face ((t (:background "#27292A"))))
 


### PR DESCRIPTION
Hi,

(sorry for the previous one - made a mistake)

First of all thanks a lot for making this theme - it rocks! I don't know if you will be interested, but I just added support for line number, current line highlight and yasnippet. It also sort of emulates textmate original colors.

You can see the result here: http://skitch.com/fikovnik/d5fh8/color-theme-twilight.el

It is unfortunately not as good as textmate as its colors are transparent. I don't know if one can do the same in emacs - put an opacity to a face background.
