### PR TITLE
Don't automatically make twilight the color theme.

### DIFF
--- a/color-theme-twilight.el
+++ b/color-theme-twilight.el
@@ -120,9 +120,6 @@
 	  (underline ((nil (:underline nil))))
 	  (zmacs-region ((t (:background "snow" :foreground "blue")))))))
 
-
-(color-theme-twilight)
-
 (provide 'color-theme-twilight)
 
 ;;; color-theme-twilight.el ends here


### PR DESCRIPTION
color-themes should not be calling themselves in their .el file. Let the user call the theme.
